### PR TITLE
[sas-analytics-pro] Fix incorrect volumes in init container

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,19 +1,7 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
 
 jobs:
@@ -29,40 +17,18 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
 
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,40 +7,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.8.1
+        uses: azure/setup-helm@v4
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.12'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
-        with:
-          version: v3.5.1
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed --config .github/linters/ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/linters/ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -20,6 +22,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/sas-analytics-pro/Chart.yaml
+++ b/charts/sas-analytics-pro/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
 
 type: application
 
-version: 0.1.1
+version: 0.1.2
 
 appVersion: "0.18.30-20220920.1663692624971"

--- a/charts/sas-analytics-pro/templates/deployment.yaml
+++ b/charts/sas-analytics-pro/templates/deployment.yaml
@@ -106,9 +106,9 @@ spec:
         {{- end }}
         volumeMounts:
           - mountPath: /sasinside
-            name: sas-analytics-pro-osconfig
+            name: sas-analytics-pro-sasinside #sas-analytics-pro-osconfig 
           - mountPath: /sasinsiderw
-            name: sas-analytics-pro-osconfigrw
+            name: sas-analytics-pro-sasinsiderw #sas-analytics-pro-osconfigrw 
           - mountPath: /osconfig
             name: sas-analytics-pro-osconfig
           - mountPath: /osconfigrw

--- a/charts/sas-analytics-pro/templates/deployment.yaml
+++ b/charts/sas-analytics-pro/templates/deployment.yaml
@@ -106,9 +106,9 @@ spec:
         {{- end }}
         volumeMounts:
           - mountPath: /sasinside
-            name: sas-analytics-pro-sasinside #sas-analytics-pro-osconfig 
+            name: sas-analytics-pro-sasinside
           - mountPath: /sasinsiderw
-            name: sas-analytics-pro-sasinsiderw #sas-analytics-pro-osconfigrw 
+            name: sas-analytics-pro-sasinsiderw
           - mountPath: /osconfig
             name: sas-analytics-pro-osconfig
           - mountPath: /osconfigrw


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes incorrect volume mounts in the init container. The init container was mounting `osconfig` at `/sasinside` and `osconfigrw` at `/sasinsiderw` — these should be `sasinside` and `sasinsiderw` respectively.

Also cleans up inline comments and bumps the chart version to `0.1.2`.

#### Which issue this PR fixes

- fixes #11

#### Changes

- `templates/deployment.yaml` — Corrected volume mount names for `/sasinside` and `/sasinsiderw` in the init container, removed inline comments
- `Chart.yaml` — Bumped version from `0.1.1` to `0.1.2`

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[sas-analytics-pro]`)
