### PR TITLE
Update Selerity website and icon URLs in chart metadata

### DIFF
--- a/charts/sas-analytics-pro/Chart.yaml
+++ b/charts/sas-analytics-pro/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: sas-analytics-pro
 description: A Helm chart to deploy SAS Analytics Pro
-home: https://seleritysas.com
-icon: https://seleritysas.com/wp-content/uploads/2017/08/cropped-logo_square-1.png
+home: https://selerity.com.au
+icon: https://assets.selerity.com.au/brand/icons/icon_selerity_purple.png
 maintainers:
   - name: seleritymichael
     email: michael.dixon@selerity.com.au
 
 type: application
 
-version: 0.1.2
+version: 0.1.3
 
 appVersion: "0.18.30-20220920.1663692624971"

--- a/charts/viya4-home-dir-builder/Chart.yaml
+++ b/charts/viya4-home-dir-builder/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: viya4-home-dir-builder
 description: Create home directories for SAS Viya 4 Users
-home: https://seleritysas.com
-icon: https://seleritysas.com/wp-content/uploads/2017/08/cropped-logo_square-1.png
+home: https://selerity.com.au
+icon: https://assets.selerity.com.au/brand/icons/icon_selerity_purple.png
 maintainers:
   - name: seleritymichael
     email: michael.dixon@selerity.com.au
 
 type: application
 
-version: 0.2.5
+version: 0.2.6
 
 appVersion: latest


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates Selerity branding across both charts — the old seleritysas.com domain is no longer in use.

#### Changes

- `sas-analytics-pro/Chart.yaml` — Updated `home` and `icon` URLs, bumped version to `0.1.3`
- `viya4-home-dir-builder/Chart.yaml` — Updated `home` and `icon` URLs, bumped version to `0.2.6`

#### Checklist

- [x] Chart Version bumped
