### PR TITLE
[viya4-home-dir-builder] Fix error when home directory doesn't exist on NFS server

### DIFF
--- a/charts/viya4-home-dir-builder/Chart.yaml
+++ b/charts/viya4-home-dir-builder/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
 
 type: application
 
-version: 0.2.6
+version: 0.2.7
 
 appVersion: latest

--- a/charts/viya4-home-dir-builder/templates/cronjob.yaml
+++ b/charts/viya4-home-dir-builder/templates/cronjob.yaml
@@ -30,7 +30,7 @@ spec:
                 name: {{ include "selerity-home-dir-builder.fullname" . }}-py
           initContainers:
             - name: ensure-home-dir
-              image: busybox:latest
+              image: busybox:1.37
               command: ['sh', '-c', 'mkdir -p /nfs{{ .Values.nfs.mount }}']
               volumeMounts:
                 - name: nfs-root

--- a/charts/viya4-home-dir-builder/templates/cronjob.yaml
+++ b/charts/viya4-home-dir-builder/templates/cronjob.yaml
@@ -17,6 +17,10 @@ spec:
             {{- toYaml . | nindent 8 }}
           {{- end }}
           volumes:
+            - name: nfs-root
+              nfs:
+                server: {{ .Values.nfs.server }}
+                path: /
             - name: userhome
               nfs:
                 server: {{ .Values.nfs.server }}
@@ -24,6 +28,13 @@ spec:
             - name: scripts
               configMap:
                 name: {{ include "selerity-home-dir-builder.fullname" . }}-py
+          initContainers:
+            - name: ensure-home-dir
+              image: busybox:latest
+              command: ['sh', '-c', 'mkdir -p /nfs{{ .Values.nfs.mount }}']
+              volumeMounts:
+                - name: nfs-root
+                  mountPath: /nfs
           containers:
             - name: home-dir-builder
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes the issue where the pod stays pending with a volume mount timeout if the home directory path doesn't exist on the NFS server (e.g. a freshly created EFS in AWS).

The fix adds an init container that:
1. Mounts the NFS server root (`/`)
2. Runs `mkdir -p` to ensure the configured home directory path exists
3. Only then does the main container mount the specific path

This ensures the `userhome` NFS volume can be mounted successfully even on a brand new NFS/EFS server with no pre-existing directories.

#### Which issue this PR fixes

- fixes #10

#### Changes

- `templates/cronjob.yaml` — Added `nfs-root` volume and `ensure-home-dir` init container
- `Chart.yaml` — Bumped version from `0.2.6` to `0.2.7`

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[viya4-home-dir-builder]`)
