### PR TITLE
[viya4-home-dir-builder] Apply Helm best practice audit findings

### DIFF
--- a/charts/viya4-home-dir-builder/Chart.yaml
+++ b/charts/viya4-home-dir-builder/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
 
 type: application
 
-version: 0.2.7
+version: 1.0.0
 
 appVersion: latest

--- a/charts/viya4-home-dir-builder/README.md
+++ b/charts/viya4-home-dir-builder/README.md
@@ -11,6 +11,12 @@ helm repo add selerity https://selerity.github.io/helm-charts
 helm repo update
 ```
 
+## Prerequisites
+
+This chart requires the following to exist in the target namespace:
+
+- A Kubernetes Secret named `sas-consul-client` (or as configured via `viya.consulSecretName`) containing the SAS Consul token. This is created automatically by the SAS Viya deployment.
+
 ## Configure your settings
 
 At a minimum you must provide values for `viya.baseUrl` and `nfs.server`. All configurable options can be examined by using the following command:

--- a/charts/viya4-home-dir-builder/README.md
+++ b/charts/viya4-home-dir-builder/README.md
@@ -1,8 +1,8 @@
 # Viya 4 Home Directory Builder
 
-This chart is for SAS Viya 4 deployments that are relying on a non-Posix identify provide (i.e. the identify provider does not manage the `uid` of each user).  This is most likely the case if you are using Samba or Active Directory as your identity provider.  In these situations Viya generates a `uid` for each user to use whenever file system operations are performed in the context of a user. This Helm Chart provides a Cron Job that can be run at regular intervals to make sure the home directories of your users have the correct `uid` (as far as Viya is concerned).
+This chart is for SAS Viya 4 deployments that are relying on a non-Posix identity provider (i.e. the identity provider does not manage the `uid` of each user). This is most likely the case if you are using Samba or Active Directory as your identity provider. In these situations Viya generates a `uid` for each user to use whenever file system operations are performed in the context of a user. This Helm Chart provides a Cron Job that can be run at regular intervals to make sure the home directories of your users have the correct `uid` (as far as Viya is concerned).
 
-**NOTE:** Do not use this cron job if the home directories being mounted into Viya are already in use with an established Linux landscape.  This will update the `uid` on user's home directories from the generated `uid` stored within Viya.
+**NOTE:** Do not use this cron job if the home directories being mounted into Viya are already in use with an established Linux landscape. This will update the `uid` on user's home directories from the generated `uid` stored within Viya.
 
 ## Add the Repo
 
@@ -13,24 +13,24 @@ helm repo update
 
 ## Configure your settings
 
-At a minimum you must provide values for `viya.base_url` and `nfs.server`.  All configurable options can be examined by using the following command:
+At a minimum you must provide values for `viya.baseUrl` and `nfs.server`. All configurable options can be examined by using the following command:
 
 ```
 helm show values selerity/viya4-home-dir-builder
 ```
 
-The default settings will create a kubernetes Cron Job that must be triggered manually (i.e. suspended), and when triggered will only report on what it will do (i.e. it will perform a `dry run`).  To allow the process to create/update home directories add the `--set dry_run=0` option to the command line.
+The default settings will create a kubernetes Cron Job that must be triggered manually (i.e. suspended), and when triggered will only report on what it will do (i.e. it will perform a `dry run`). To allow the process to create/update home directories add the `--set dryRun=0` option to the command line.
 
 ## Install Chart
 
 ```
-helm install -n[VIYA_NAMESPACE] [RELEASE_NAME] selerity/viya4-home-dir-builder --set viya.base_url=[VIYA_BASE_URL] --set nfs.server=[NFS_SERVER_NAME]
+helm install -n[VIYA_NAMESPACE] [RELEASE_NAME] selerity/viya4-home-dir-builder --set viya.baseUrl=[VIYA_BASE_URL] --set nfs.server=[NFS_SERVER_NAME]
 ```
 
 Example:
 
 ```
-helm install -nviya thor selerity/viya4-home-dir-builder --set viya.base_url=https://viya.server.com --set nfs.server=mynfs.server.com
+helm install -nviya thor selerity/viya4-home-dir-builder --set viya.baseUrl=https://viya.server.com --set nfs.server=mynfs.server.com
 ```
 
 ## Uninstall Chart
@@ -42,5 +42,23 @@ helm uninstall -n[VIYA_NAMESPACE] [RELEASE_NAME]
 ## Upgrading Chart
 
 ```
-helm upgrade -n[VIYA_NAMESPACE] [RELEASE_NAME] selerity/viya4-home-dir-builder --install --set viya.base_url=[VIYA_BASE_URL] --set nfs.server=[NFS_SERVER_NAME]
+helm upgrade -n[VIYA_NAMESPACE] [RELEASE_NAME] selerity/viya4-home-dir-builder --install --set viya.baseUrl=[VIYA_BASE_URL] --set nfs.server=[NFS_SERVER_NAME]
 ```
+
+### Upgrading to 1.0.0
+
+This release includes breaking changes. All values have been renamed from snake_case to camelCase:
+
+| Old Value | New Value |
+|-----------|-----------|
+| `viya.base_url` | `viya.baseUrl` |
+| `viya.home_dir_location` | `viya.homeDirLocation` |
+| `viya.user_exceptions` | `viya.userExceptions` |
+| `oauth.client_id` | `oauth.clientId` |
+| `dry_run` | `dryRun` |
+
+Additional changes:
+- `image.pullPolicy` now defaults to `Always` (image tag defaults to `latest`)
+- Resource requests and limits are now configured by default
+- Standard Kubernetes labels (`app.kubernetes.io/*`) are now applied to all resources
+- Template prefix changed from `selerity-home-dir-builder` to `viya4-home-dir-builder`

--- a/charts/viya4-home-dir-builder/ci/lint-values.yaml
+++ b/charts/viya4-home-dir-builder/ci/lint-values.yaml
@@ -1,0 +1,16 @@
+viya:
+  baseUrl: "https://viya.example.com"
+  homeDirLocation: /home
+  userExceptions: Administrator
+
+nfs:
+  server: "nfs.example.com"
+  mount: /home
+
+oauth:
+  clientId: test.client
+
+image:
+  repository: selerity/python-core
+  pullPolicy: Always
+  tag: latest

--- a/charts/viya4-home-dir-builder/templates/NOTES.txt
+++ b/charts/viya4-home-dir-builder/templates/NOTES.txt
@@ -1,20 +1,20 @@
 ===============================================================================
 Home Directory Builder for SAS Viya 4
-(c) Selerity Pty Ltd 2022
+(c) Selerity Pty Ltd
 ===============================================================================
 
 1. Review status of CronJob:
 
-kubectl -n{{ .Release.Namespace }} get cronjob {{ include "selerity-home-dir-builder.fullname" . }}
+kubectl -n{{ .Release.Namespace }} get cronjob {{ include "viya4-home-dir-builder.fullname" . }}
 
 2. Manually trigger a one-time run:
 
-kubectl -n{{ .Release.Namespace }} create job --from=cronjob/{{ include "selerity-home-dir-builder.fullname" . }} my-unique-job-name
+kubectl -n{{ .Release.Namespace }} create job --from=cronjob/{{ include "viya4-home-dir-builder.fullname" . }} my-unique-job-name
 
 3. Get list of Job Runs
 
-kubectl -n{{ .Release.Namespace }} get jobs -l created-by={{ include "selerity-home-dir-builder.fullname" . }}
+kubectl -n{{ .Release.Namespace }} get jobs -l app.kubernetes.io/instance={{ .Release.Name }}
 
 4. Get Logs of Job Runs
 
-kubectl -n{{ .Release.Namespace }} logs -l created-by={{ include "selerity-home-dir-builder.fullname" . }}
+kubectl -n{{ .Release.Namespace }} logs -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/charts/viya4-home-dir-builder/templates/_helpers.tpl
+++ b/charts/viya4-home-dir-builder/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "selerity-home-dir-builder.name" -}}
+{{- define "viya4-home-dir-builder.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "selerity-home-dir-builder.fullname" -}}
+{{- define "viya4-home-dir-builder.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "selerity-home-dir-builder.chart" -}}
+{{- define "viya4-home-dir-builder.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "selerity-home-dir-builder.labels" -}}
-helm.sh/chart: {{ include "selerity-home-dir-builder.chart" . }}
-{{ include "selerity-home-dir-builder.selectorLabels" . }}
+{{- define "viya4-home-dir-builder.labels" -}}
+helm.sh/chart: {{ include "viya4-home-dir-builder.chart" . }}
+{{ include "viya4-home-dir-builder.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,17 +45,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "selerity-home-dir-builder.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "selerity-home-dir-builder.name" . }}
+{{- define "viya4-home-dir-builder.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "viya4-home-dir-builder.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "selerity-home-dir-builder.serviceAccountName" -}}
+{{- define "viya4-home-dir-builder.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "selerity-home-dir-builder.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "viya4-home-dir-builder.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/viya4-home-dir-builder/templates/configmap.yaml
+++ b/charts/viya4-home-dir-builder/templates/configmap.yaml
@@ -1,11 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "selerity-home-dir-builder.fullname" . }}
+  name: {{ include "viya4-home-dir-builder.fullname" . }}
+  labels:
+    {{- include "viya4-home-dir-builder.labels" . | nindent 4 }}
 data:
-  VIYA_BASE_URL: "{{ .Values.viya.base_url }}"
-  CLIENT_ID: "{{ .Values.oauth.client_id }}"
-  HOME_DIR_PATH: "{{ .Values.viya.home_dir_location }}"
-  USER_EXCEPTIONS: "{{ .Values.viya.user_exceptions }}"
-  DEBUG: "{{ .Values.debug }}"
-  DRY_RUN: "{{ .Values.dry_run }}"
+  VIYA_BASE_URL: {{ .Values.viya.baseUrl | quote }}
+  CLIENT_ID: {{ .Values.oauth.clientId | quote }}
+  HOME_DIR_PATH: {{ .Values.viya.homeDirLocation | quote }}
+  USER_EXCEPTIONS: {{ .Values.viya.userExceptions | quote }}
+  DEBUG: {{ .Values.debug | quote }}
+  DRY_RUN: {{ .Values.dryRun | quote }}

--- a/charts/viya4-home-dir-builder/templates/configmapfiles.yaml
+++ b/charts/viya4-home-dir-builder/templates/configmapfiles.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "selerity-home-dir-builder.fullname" . }}-py
+  name: {{ include "viya4-home-dir-builder.fullname" . }}-py
+  labels:
+    {{- include "viya4-home-dir-builder.labels" . | nindent 4 }}
 data:
   home_dir_builder.py: |-
 {{ .Files.Get "home_dir_builder.py" | indent 4 }}

--- a/charts/viya4-home-dir-builder/templates/cronjob.yaml
+++ b/charts/viya4-home-dir-builder/templates/cronjob.yaml
@@ -1,21 +1,27 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "selerity-home-dir-builder.fullname" . }}
+  name: {{ include "viya4-home-dir-builder.fullname" . }}
+  labels:
+    {{- include "viya4-home-dir-builder.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.schedule }}
+  schedule: {{ .Values.schedule | quote }}
   suspend: {{ .Values.suspend }}
   jobTemplate:
+    metadata:
+      labels:
+        {{- include "viya4-home-dir-builder.labels" . | nindent 8 }}
     spec:
       template:
         metadata:
           labels:
-            created-by: {{ include "selerity-home-dir-builder.fullname" . }}
+            {{- include "viya4-home-dir-builder.selectorLabels" . | nindent 12 }}
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 8 }}
           {{- end }}
+          serviceAccountName: {{ include "viya4-home-dir-builder.serviceAccountName" . }}
           volumes:
             - name: nfs-root
               nfs:
@@ -27,7 +33,7 @@ spec:
                 path: {{ .Values.nfs.mount }}
             - name: scripts
               configMap:
-                name: {{ include "selerity-home-dir-builder.fullname" . }}-py
+                name: {{ include "viya4-home-dir-builder.fullname" . }}-py
           initContainers:
             - name: ensure-home-dir
               image: busybox:1.37
@@ -39,19 +45,21 @@ spec:
             - name: home-dir-builder
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              command: ["python",  "/scripts/home_dir_builder.py"]
+              command: ["python", "/scripts/home_dir_builder.py"]
               envFrom:
-                - secretRef: 
+                - secretRef:
                     name: sas-consul-client
                 - secretRef:
-                    name: {{ include "selerity-home-dir-builder.fullname" . }}
+                    name: {{ include "viya4-home-dir-builder.fullname" . }}
                 - configMapRef:
-                    name: {{ include "selerity-home-dir-builder.fullname" . }}
+                    name: {{ include "viya4-home-dir-builder.fullname" . }}
               volumeMounts:
                 - name: userhome
-                  mountPath: {{ .Values.viya.home_dir_location }}
+                  mountPath: {{ .Values.viya.homeDirLocation }}
                 - name: scripts
                   mountPath: /scripts
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
           restartPolicy: Never
           {{- with .Values.nodeSelector }}
           nodeSelector:

--- a/charts/viya4-home-dir-builder/templates/cronjob.yaml
+++ b/charts/viya4-home-dir-builder/templates/cronjob.yaml
@@ -48,7 +48,7 @@ spec:
               command: ["python", "/scripts/home_dir_builder.py"]
               envFrom:
                 - secretRef:
-                    name: sas-consul-client
+                    name: {{ .Values.viya.consulSecretName | default "sas-consul-client" }}
                 - secretRef:
                     name: {{ include "viya4-home-dir-builder.fullname" . }}
                 - configMapRef:

--- a/charts/viya4-home-dir-builder/templates/role.yaml
+++ b/charts/viya4-home-dir-builder/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "viya4-home-dir-builder.fullname" . }}
+  labels:
+    {{- include "viya4-home-dir-builder.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+{{- end }}

--- a/charts/viya4-home-dir-builder/templates/rolebinding.yaml
+++ b/charts/viya4-home-dir-builder/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "viya4-home-dir-builder.fullname" . }}
+  labels:
+    {{- include "viya4-home-dir-builder.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "viya4-home-dir-builder.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "viya4-home-dir-builder.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/viya4-home-dir-builder/templates/secret.yaml
+++ b/charts/viya4-home-dir-builder/templates/secret.yaml
@@ -10,6 +10,6 @@ type: Opaque
 {{- $secretName := (include "viya4-home-dir-builder.fullname" .) }}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) | default dict }}
 {{- $existingData := (get $existingSecret "data") | default dict }}
-{{- $clientSecret := (get $existingData "CLIENT_SECRET" | b64dec) | default (randAlphaNum 32) }}
-stringData:
-  CLIENT_SECRET: {{ $clientSecret | quote }}
+{{- $clientSecret := (get $existingData "CLIENT_SECRET") | default (randAlphaNum 32 | b64enc) }}
+data:
+  CLIENT_SECRET: {{ $clientSecret }}

--- a/charts/viya4-home-dir-builder/templates/secret.yaml
+++ b/charts/viya4-home-dir-builder/templates/secret.yaml
@@ -1,12 +1,15 @@
-{{- $client_secret := "" }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "selerity-home-dir-builder.fullname" . }}
+  name: {{ include "viya4-home-dir-builder.fullname" . }}
+  labels:
+    {{- include "viya4-home-dir-builder.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": "keep"
 type: Opaque
+{{- $secretName := (include "viya4-home-dir-builder.fullname" .) }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) | default dict }}
+{{- $existingData := (get $existingSecret "data") | default dict }}
+{{- $clientSecret := (get $existingData "CLIENT_SECRET" | b64dec) | default (randAlphaNum 32) }}
 stringData:
-  {{- $secret := (lookup "v1" "Secret" .Release.Namespace "{{ include \"selerity-home-dir-builder.fullname\" . }}") | default dict }}
-  {{- $client_secret := (get $secret "{{ include \"selerity-home-dir-builder.fullname\" . }}") | default (randAlphaNum 32 | b64enc) }}
-  CLIENT_SECRET: {{ $client_secret }}
+  CLIENT_SECRET: {{ $clientSecret | quote }}

--- a/charts/viya4-home-dir-builder/templates/serviceaccount.yaml
+++ b/charts/viya4-home-dir-builder/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "viya4-home-dir-builder.serviceAccountName" . }}
+  labels:
+    {{- include "viya4-home-dir-builder.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/viya4-home-dir-builder/templates/tests/test-connection.yaml
+++ b/charts/viya4-home-dir-builder/templates/tests/test-connection.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "viya4-home-dir-builder.fullname" . }}-test"
+  labels:
+    {{- include "viya4-home-dir-builder.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: test-config
+      image: busybox:1.37
+      command: ['sh', '-c', 'echo "Chart installed successfully"']
+  restartPolicy: Never

--- a/charts/viya4-home-dir-builder/values.yaml
+++ b/charts/viya4-home-dir-builder/values.yaml
@@ -29,6 +29,9 @@ viya:
   homeDirLocation: /home
   # A comma separated list of user ids you do not want home directories for
   userExceptions: Administrator
+  # Name of the existing Kubernetes secret containing the SAS Consul token
+  # This secret must exist in the target namespace (created by SAS Viya deployment)
+  consulSecretName: sas-consul-client
 
 nfs:
   # Host name of the NFS Server hosting the home directories

--- a/charts/viya4-home-dir-builder/values.yaml
+++ b/charts/viya4-home-dir-builder/values.yaml
@@ -1,10 +1,10 @@
-# Default values for selerity-home-dir-builder.
+# Default values for viya4-home-dir-builder.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 image:
   repository: selerity/python-core
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest
 
@@ -12,20 +12,23 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-schedule: 0,15,30,45 * * * *
+# Cron schedule for the job
+schedule: "0,15,30,45 * * * *"
 # If suspend is set to true, then you must manually trigger the job
 # If suspend is set to false, then the job will run on the schedule above
 suspend: true
+# Enable debug logging (0 = off, 1 = on)
 debug: 0
-dry_run: 1
+# Dry run mode (1 = report only, 0 = create/update directories)
+dryRun: 1
 
 viya:
-  # The base URL of SAS Viya. e.g. https://viya.company.com
-  base_url: https://viya.company.com
+  # The base URL of SAS Viya (e.g. https://viya.company.com)
+  baseUrl: https://viya.company.com
   # The location within the container to mount the home directories to
-  home_dir_location: /home
+  homeDirLocation: /home
   # A comma separated list of user ids you do not want home directories for
-  user_exceptions: Administrator
+  userExceptions: Administrator
 
 nfs:
   # Host name of the NFS Server hosting the home directories
@@ -34,7 +37,30 @@ nfs:
   mount: /home
 
 oauth:
-  client_id: selerity.homedir_builder
+  # OAuth client ID for Viya API access
+  clientId: selerity.homedir_builder
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Resources for the main container
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Implements all findings from the Helm best practice audit for viya4-home-dir-builder. This is a major refactor that brings the chart in line with Helm conventions.

#### Breaking Changes

All snake_case values renamed to camelCase:

| Old Value | New Value |
|-----------|-----------|
| `viya.base_url` | `viya.baseUrl` |
| `viya.home_dir_location` | `viya.homeDirLocation` |
| `viya.user_exceptions` | `viya.userExceptions` |
| `oauth.client_id` | `oauth.clientId` |
| `dry_run` | `dryRun` |

#### Changes

**Templates:**
- `_helpers.tpl` — Renamed template prefix from `selerity-home-dir-builder` to `viya4-home-dir-builder`
- `cronjob.yaml` — Applied standard `app.kubernetes.io/*` labels, added resource limits, added serviceAccount reference, quoted schedule
- `configmap.yaml` — Updated to use camelCase values, added labels, quoted all values
- `configmapfiles.yaml` — Updated template prefix, added labels
- `secret.yaml` — Fixed secret lookup logic, updated template prefix, added labels
- `NOTES.txt` — Updated template prefix, use standard label selectors

**New files:**
- `templates/tests/test-connection.yaml` — Basic Helm test
- `ci/lint-values.yaml` — Values for chart-testing CI

**Values:**
- Renamed all snake_case values to camelCase
- Changed `imagePullPolicy` default to `Always` (tag is `latest`)
- Added `resources` with default CPU/memory requests and limits
- Added `rbac.create` and `serviceAccount.create` toggles

**Documentation:**
- Updated README with new value names and upgrade migration guide

**Version:**
- Bumped chart version to `1.0.0`

#### Which issue this PR fixes

- closes #21

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[viya4-home-dir-builder]`)
