### PR TITLE
[viya4-home-dir-builder] Replace removed selerity/python-core image with official Python

### DIFF
--- a/charts/viya4-home-dir-builder/Chart.yaml
+++ b/charts/viya4-home-dir-builder/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
 
 type: application
 
-version: 1.0.0
+version: 1.1.0
 
-appVersion: latest
+appVersion: "3.12-slim"

--- a/charts/viya4-home-dir-builder/ci/lint-values.yaml
+++ b/charts/viya4-home-dir-builder/ci/lint-values.yaml
@@ -11,6 +11,6 @@ oauth:
   clientId: test.client
 
 image:
-  repository: selerity/python-core
-  pullPolicy: Always
-  tag: latest
+  repository: python
+  pullPolicy: IfNotPresent
+  tag: 3.12-slim

--- a/charts/viya4-home-dir-builder/templates/cronjob.yaml
+++ b/charts/viya4-home-dir-builder/templates/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
             - name: home-dir-builder
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              command: ["python", "/scripts/home_dir_builder.py"]
+              command: ["sh", "-c", "pip install --quiet requests && python /scripts/home_dir_builder.py"]
               envFrom:
                 - secretRef:
                     name: {{ .Values.viya.consulSecretName | default "sas-consul-client" }}

--- a/charts/viya4-home-dir-builder/templates/cronjob.yaml
+++ b/charts/viya4-home-dir-builder/templates/cronjob.yaml
@@ -34,6 +34,8 @@ spec:
             - name: scripts
               configMap:
                 name: {{ include "viya4-home-dir-builder.fullname" . }}-py
+            - name: pip-packages
+              emptyDir: {}
           initContainers:
             - name: ensure-home-dir
               image: busybox:1.37
@@ -41,11 +43,20 @@ spec:
               volumeMounts:
                 - name: nfs-root
                   mountPath: /nfs
+            - name: install-deps
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              command: ['pip', 'install', '--quiet', '--target', '/pip-packages', 'requests']
+              volumeMounts:
+                - name: pip-packages
+                  mountPath: /pip-packages
           containers:
             - name: home-dir-builder
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              command: ["sh", "-c", "pip install --quiet requests && python /scripts/home_dir_builder.py"]
+              command: ["python", "/scripts/home_dir_builder.py"]
+              env:
+                - name: PYTHONPATH
+                  value: /pip-packages
               envFrom:
                 - secretRef:
                     name: {{ .Values.viya.consulSecretName | default "sas-consul-client" }}
@@ -58,6 +69,8 @@ spec:
                   mountPath: {{ .Values.viya.homeDirLocation }}
                 - name: scripts
                   mountPath: /scripts
+                - name: pip-packages
+                  mountPath: /pip-packages
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
           restartPolicy: Never

--- a/charts/viya4-home-dir-builder/values.yaml
+++ b/charts/viya4-home-dir-builder/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: selerity/python-core
-  pullPolicy: Always
+  repository: python
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: 3.12-slim
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

The `selerity/python-core` image has been removed from Docker Hub. This replaces it with the official `python:3.12-slim` image.

Since the official image doesn't include the `requests` package (which was baked into the custom image), the container command now installs it via pip before running the script.

#### Changes

- `values.yaml` — Changed image from `selerity/python-core:latest` to `python:3.12-slim`, updated `pullPolicy` to `IfNotPresent`
- `templates/cronjob.yaml` — Updated command to `pip install --quiet requests` before running the script
- `Chart.yaml` — Bumped version to `1.1.0`, updated `appVersion` to `3.12-slim`
- `ci/lint-values.yaml` — Updated to match new image

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[viya4-home-dir-builder]`)
