### PR TITLE
[sas-analytics-pro] Replace selerity/sas-tools with alpine + direct SAS API calls

### DIFF
--- a/charts/sas-analytics-pro/Chart.yaml
+++ b/charts/sas-analytics-pro/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
 
 type: application
 
-version: 1.0.0
+version: 1.1.0
 
 appVersion: "0.18.30-20220920.1663692624971"

--- a/charts/sas-analytics-pro/README.md
+++ b/charts/sas-analytics-pro/README.md
@@ -17,7 +17,7 @@ At a minimum you must provide values for `sas.order`, `sas.registryPass` and `sa
 helm show values selerity/sas-analytics-pro
 ```
 
-The `sas.registryPass` value can be found by using the `mirrormgr list remote docker login` command as described in [Step 2 — Access the Container Image](https://documentation.sas.com/doc/en/anprocdc/v_011/dplyviya0ctr/p0ot22u2rapcsfn1outngvut0f8m.htm#p0xt4ltecfl3gan1rvt589xgjpu6) of the official SAS Documentation.  Use the value shown as `randompasswordvalue` in the SAS documentation.
+The `sas.registryPass` value can be found in the SAS documentation for [Step 2 — Access the Container Image](https://documentation.sas.com/doc/en/anprocdc/v_011/dplyviya0ctr/p0ot22u2rapcsfn1outngvut0f8m.htm#p0xt4ltecfl3gan1rvt589xgjpu6). Use the value shown as `randompasswordvalue` in the SAS documentation.
 
 ## Install Chart
 
@@ -42,6 +42,12 @@ helm uninstall -n[VIYA_NAMESPACE] [RELEASE_NAME]
 ```
 helm upgrade -n[VIYA_NAMESPACE] [RELEASE_NAME] selerity/sas-analytics-pro --install --set sas.order=[ORDER] --set sas.registryPass=[REGISTRY_PASSWORD] --set-file sas.license=[PATH_TO_LICENSE_FILE]
 ```
+
+### Upgrading to 1.1.0
+
+- The init container no longer uses the `selerity/sas-tools` image. It now uses `alpine:3.21` and calls the SAS Orders API directly via `curl` instead of relying on `mirrormgr` and `viya4-orders-cli`.
+- New `initImage` value allows overriding the init container image.
+- If you were providing `sas.ordersApiKey` and `sas.ordersApiSecret`, the license download now uses the SAS API directly — no behaviour change required.
 
 ### Upgrading to 1.0.0
 

--- a/charts/sas-analytics-pro/boot.sh
+++ b/charts/sas-analytics-pro/boot.sh
@@ -1,39 +1,76 @@
 #!/bin/bash
 
+SAS_API_BASE="https://api.apiproxy.sas.com/mysas"
+
 # Prepare Environment File
 echo "# SAS Analytics Pro Environment" > /sas-env/sas-env.sh
 
-# Obtain SAS Container Registry credentials
-if [ -f /certs.zip ]; then
-    echo "Processing Certificate File"
-    # Obtain SAS Container Registry credentials
-    dl=$(mirrormgr list remote docker login --deployment-data /certs.zip)
-    order=${dl#docker login -u }
-    order=${order% -p*}
-    secret=${dl#docker* -p }
-    secret=${secret% cr.sas*}
-    secret=$(tr -d "'" <<< "$secret")
-    echo "ORDER=${order}" >> /sas-env/sas-env.sh
-    echo "REGISTRYSECRET=\"${secret}\"" >> /sas-env/sas-env.sh
+# Download license via SAS Orders API
+if [ "${CLIENTCREDENTIALSID}x" != "x" ] && [ "${CLIENTCREDENTIALSSECRET}x" != "x" ] && [ "${ORDER}x" != "x" ] && [ "${CADENCENAME}x" != "x" ] && [ "${CADENCEVERSION}x" != "x" ]; then
+    echo "Downloading license from SAS Orders API..."
+    curl -sf \
+        -H "ClientId: ${CLIENTCREDENTIALSID}" \
+        -H "ClientSecret: ${CLIENTCREDENTIALSSECRET}" \
+        -o /sasinsiderw/license.jwt \
+        "${SAS_API_BASE}/orders/${ORDER}/cadences/${CADENCENAME}/${CADENCEVERSION}/license"
 
-    # Get available image versions
-    #mirrormgr list remote docker tags --deployment-data /certs.zip | grep sas-analytics-pro | cut -d':' -f2 > /sas-env/apro-versions.txt
-
-    # Get available cadences
-
+    if [ $? -eq 0 ]; then
+        echo "License downloaded successfully."
+    else
+        echo "ERROR: Failed to download license from SAS Orders API."
+    fi
 fi
 
-if [ "${CLIENTCREDENTIALSID}x" != "x" ] && [ "${CLIENTCREDENTIALSSECRET}x" != "x" ] && [ "${ORDER}x" != "x" ] && [ "${CADENCENAME}x" != "x" ] && [ "${CADENCEVERSION}x" != "x" ]; then
-    echo "SAS Viya Orders API credentials and Cadence Info found."
-    # if [ -z ${ORDER+x} ]; then
-    #     if [ -z ${order+x} ]; then
-    #         echo "ERROR: SAS Viya Orders API cannot be used because ORDER is not set"
-    #     else
-    #         ORDER=${order}
-    #     fi
-    # fi
-    viya4-orders-cli license "${ORDER}" "${CADENCENAME}" "${CADENCEVERSION}" -p /sasinsiderw -n license
+# Download and extract certificates for registry credentials
+if [ -f /certs.zip ]; then
+    echo "Processing provided certificate file..."
+    mkdir -p /tmp/certs
+    unzip -qo /certs.zip -d /tmp/certs
 
+    # Extract registry credentials from the entitlement certificate
+    PEM_FILE=$(find /tmp/certs -name "entitlement_certificate.pem" -type f | head -1)
+    if [ -n "$PEM_FILE" ]; then
+        # The order number is the CN in the certificate subject
+        order=$(openssl x509 -in "$PEM_FILE" -noout -subject 2>/dev/null | sed -n 's/.*CN *= *//p')
+        # The registry password is the base64-encoded certificate + key
+        secret=$(cat "$PEM_FILE" | base64 -w 0 2>/dev/null || cat "$PEM_FILE" | base64 2>/dev/null)
+        if [ -n "$order" ] && [ -n "$secret" ]; then
+            echo "ORDER=${order}" >> /sas-env/sas-env.sh
+            echo "REGISTRYSECRET=\"${secret}\"" >> /sas-env/sas-env.sh
+            echo "Registry credentials extracted from certificate."
+        fi
+    else
+        echo "WARNING: No entitlement_certificate.pem found in certificate archive."
+    fi
+    rm -rf /tmp/certs
+elif [ "${CLIENTCREDENTIALSID}x" != "x" ] && [ "${CLIENTCREDENTIALSSECRET}x" != "x" ] && [ "${ORDER}x" != "x" ]; then
+    echo "Downloading certificates from SAS Orders API..."
+    curl -sf \
+        -H "ClientId: ${CLIENTCREDENTIALSID}" \
+        -H "ClientSecret: ${CLIENTCREDENTIALSSECRET}" \
+        -o /tmp/certs.zip \
+        "${SAS_API_BASE}/orders/${ORDER}/certificates"
+
+    if [ $? -eq 0 ] && [ -f /tmp/certs.zip ]; then
+        mkdir -p /tmp/certs
+        unzip -qo /tmp/certs.zip -d /tmp/certs
+
+        PEM_FILE=$(find /tmp/certs -name "entitlement_certificate.pem" -type f | head -1)
+        if [ -n "$PEM_FILE" ]; then
+            order=$(openssl x509 -in "$PEM_FILE" -noout -subject 2>/dev/null | sed -n 's/.*CN *= *//p')
+            secret=$(cat "$PEM_FILE" | base64 -w 0 2>/dev/null || cat "$PEM_FILE" | base64 2>/dev/null)
+            if [ -n "$order" ] && [ -n "$secret" ]; then
+                echo "ORDER=${order}" >> /sas-env/sas-env.sh
+                echo "REGISTRYSECRET=\"${secret}\"" >> /sas-env/sas-env.sh
+                echo "Registry credentials extracted from downloaded certificate."
+            fi
+        else
+            echo "WARNING: No entitlement_certificate.pem found in downloaded archive."
+        fi
+        rm -rf /tmp/certs /tmp/certs.zip
+    else
+        echo "ERROR: Failed to download certificates from SAS Orders API."
+    fi
 fi
 
 # Copy files

--- a/charts/sas-analytics-pro/boot.sh
+++ b/charts/sas-analytics-pro/boot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SAS_API_BASE="https://api.apiproxy.sas.com/mysas"
 
@@ -31,9 +31,7 @@ if [ -f /certs.zip ]; then
     # Extract registry credentials from the entitlement certificate
     PEM_FILE=$(find /tmp/certs -name "entitlement_certificate.pem" -type f | head -1)
     if [ -n "$PEM_FILE" ]; then
-        # The order number is the CN in the certificate subject
         order=$(openssl x509 -in "$PEM_FILE" -noout -subject 2>/dev/null | sed -n 's/.*CN *= *//p')
-        # The registry password is the base64-encoded certificate + key
         secret=$(cat "$PEM_FILE" | base64 -w 0 2>/dev/null || cat "$PEM_FILE" | base64 2>/dev/null)
         if [ -n "$order" ] && [ -n "$secret" ]; then
             echo "ORDER=${order}" >> /sas-env/sas-env.sh
@@ -80,14 +78,12 @@ if [ -f /authinfo.txt ]; then
     echo "Copying authinfo file"
     cp -v /authinfo.txt /data/
 fi
-osfiles=(/osconfig/*)
-if [ ${#osfiles[@]} -gt 0 ]; then
+if [ "$(ls /osconfig/ 2>/dev/null)" ]; then
     echo "Copying osconfig files"
     cp -v /osconfig/* /osconfigrw/
     chmod -v 644 /osconfigrw/*
 fi
-infiles=(/sasinside/*)
-if [ ${#infiles[@]} -gt 0 ]; then
+if [ "$(ls /sasinside/ 2>/dev/null)" ]; then
     echo "Copying sasinside files"
     cp -v /sasinside/* /sasinsiderw/
     chmod -v 644 /sasinsiderw/*

--- a/charts/sas-analytics-pro/boot.sh
+++ b/charts/sas-analytics-pro/boot.sh
@@ -18,6 +18,7 @@ if [ "${CLIENTCREDENTIALSID}x" != "x" ] && [ "${CLIENTCREDENTIALSSECRET}x" != "x
         echo "License downloaded successfully."
     else
         echo "ERROR: Failed to download license from SAS Orders API."
+        exit 1
     fi
 fi
 
@@ -70,6 +71,7 @@ elif [ "${CLIENTCREDENTIALSID}x" != "x" ] && [ "${CLIENTCREDENTIALSSECRET}x" != 
         rm -rf /tmp/certs /tmp/certs.zip
     else
         echo "ERROR: Failed to download certificates from SAS Orders API."
+        exit 1
     fi
 fi
 

--- a/charts/sas-analytics-pro/ci/lint-values.yaml
+++ b/charts/sas-analytics-pro/ci/lint-values.yaml
@@ -8,6 +8,11 @@ image:
   pullPolicy: IfNotPresent
   tag: "latest"
 
+initImage:
+  repository: alpine
+  tag: "3.21"
+  pullPolicy: IfNotPresent
+
 probe:
   port: http
   path: /index.html

--- a/charts/sas-analytics-pro/templates/deployment.yaml
+++ b/charts/sas-analytics-pro/templates/deployment.yaml
@@ -64,9 +64,9 @@ spec:
     {{- end }}
       initContainers:
       - name: {{ .Chart.Name }}-init
-        image: selerity/sas-tools:latest
-        imagePullPolicy: Always
-        command: ['sh', '-c', '/init/boot.sh']
+        image: {{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}
+        imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+        command: ['sh', '-c', 'apk add --no-cache curl unzip openssl && /init/boot.sh']
         env:
           - name: CHARTVERSION
             value: "{{ .Chart.Version }}"

--- a/charts/sas-analytics-pro/templates/deployment.yaml
+++ b/charts/sas-analytics-pro/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
       - name: {{ .Chart.Name }}-init
         image: {{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}
         imagePullPolicy: {{ .Values.initImage.pullPolicy }}
-        command: ['sh', '-c', 'apk add --no-cache curl unzip openssl && /init/boot.sh']
+        command: ['sh', '-c', 'apk add --no-cache curl unzip openssl || exit 1; /init/boot.sh']
         env:
           - name: CHARTVERSION
             value: "{{ .Chart.Version }}"

--- a/charts/sas-analytics-pro/values.yaml
+++ b/charts/sas-analytics-pro/values.yaml
@@ -109,6 +109,12 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# Image used by the init container for pre-deployment setup
+initImage:
+  repository: alpine
+  tag: "3.21"
+  pullPolicy: IfNotPresent
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes the dependency on the `selerity/sas-tools` Docker image (which bundled `mirrormgr` and `viya4-orders-cli`) and replaces it with direct SAS Orders API calls using `curl`.

This approach mirrors what we've already done in the [selerity-desktop-docker-extension](https://github.com/Selerity/selerity-desktop-docker-extension) where we replaced these CLI tools with native HTTP calls to `api.apiproxy.sas.com`.

#### How it works

The rewritten `boot.sh` now:

1. **License download** — `curl` with `ClientId`/`ClientSecret` headers to `api.apiproxy.sas.com/mysas/orders/{ORDER}/cadences/{CADENCENAME}/{CADENCEVERSION}/license`
2. **Certificate download** — `curl` to `api.apiproxy.sas.com/mysas/orders/{ORDER}/certificates`, then `unzip` + `openssl` to extract registry credentials from the entitlement PEM
3. **File copies** — Same as before (authinfo, osconfig, sasinside)

The init container uses `alpine:3.21` with `curl`, `unzip`, and `openssl` installed at runtime.

#### Changes

- `boot.sh` — Complete rewrite using direct API calls instead of CLI tools
- `templates/deployment.yaml` — Init container image now configurable via `initImage` values
- `values.yaml` — Added `initImage` configuration (defaults to `alpine:3.21`)
- `ci/lint-values.yaml` — Added `initImage` for CI testing
- `Chart.yaml` — Bumped version to `1.1.0`
- `README.md` — Added upgrade notes, removed `mirrormgr` reference

#### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[sas-analytics-pro]`)
