### PR TITLE
chore(viya4-home-dir-builder): deprecate v1.0.0

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+# Artifact Hub repository metadata file
+ignore:
+  - name: viya4-home-dir-builder
+    version: "1.0.0"


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @SelerityMichael :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Deprecates version 1.0.0 of the `viya4-home-dir-builder` Helm chart by adding an `artifacthub-repo.yml` file to the repository root.

## Problem

Version 1.0.0 references a container image that is no longer available, causing ArtifactHub to report scanning errors for this repository.

## Changes

- Added `artifacthub-repo.yml` at the repo root with an `ignore` directive telling ArtifactHub to skip indexing version 1.0.0 of `viya4-home-dir-builder`

## Notes

- The current chart version (1.1.0) is unaffected
- `deprecated: true` was intentionally NOT added to `Chart.yaml` as that would mark the entire chart as deprecated, not just the old version
- Once this is merged and ArtifactHub re-processes the repository, it will stop scanning/indexing the problematic v1.0.0